### PR TITLE
fix: unsupported attribute when using policy_bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2]
+
+### Fixed
+
+- unsupported attribute when using policy_bindings
+
 ## [0.1.1]
 
 ### Added
@@ -22,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdown-link-check-disable -->
 
 [unreleased]: https://github.com/mineiros-io/terraform-google-secret-manager/compare/v0.1.1...HEAD
+[0.1.2]: https://github.com/mineiros-io/terraform-google-secret-manager/compare/v0.1.1...v0.1.2
 [0.1.1]: https://github.com/mineiros-io/terraform-google-secret-manager/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/mineiros-io/terraform-google-secret-manager/releases/tag/v0.1.0
 

--- a/iam.tf
+++ b/iam.tf
@@ -17,8 +17,8 @@ module "iam" {
   module_depends_on = var.module_depends_on
 
   secret_id       = google_secret_manager_secret.secret[0].secret_id
-  role            = each.value.role
-  members         = each.value.members
+  role            = try(each.value.role, null)
+  members         = try(each.value.members, null)
   authoritative   = try(each.value.authoritative, true)
   policy_bindings = try(each.value.policy_bindings, null)
 }


### PR DESCRIPTION
When using `policy_bindings` the following issue occurs:

```
Error: Unsupported attribute

  on .terraform/modules/secret/iam.tf line 21, in module "iam":
  21:   members         = each.value.members
    |----------------
    | each.value is object with 1 attribute "policy_bindings"

This object does not have an attribute named "members".
```